### PR TITLE
added option to only count x amount of locked days

### DIFF
--- a/src/calendar.ts
+++ b/src/calendar.ts
@@ -47,6 +47,7 @@ export class Calendar {
     disallowLockDaysInRange: true,
     lockDaysInclusivity: '[]',
     countLockedDays: false,
+    countLockedDaysMax: 0,
 
     holidaysFormat: 'YYYY-MM-DD',
     holidays: [],
@@ -550,6 +551,56 @@ export class Calendar {
                 ) {
                   additionalDays = additionalDays + 1;
                   maxDays = maxDays + 1;
+                }
+              }
+            }
+          }
+        }
+      } else if (this.options.countLockedDaysMax !== 0) {
+        // First right date
+        let rightDate = this.datePicked[0].clone();
+
+        // Max days setting
+        let maxDays = this.options.maxDays;
+
+        // Maximum number of days to count
+        let maxDaysCount = this.options.countLockedDaysMax;
+
+        // Lockdays > picked date
+        const relevantLockDays = [];
+        const overbookableDays = [
+          // this.options.holidays,
+          this.options.lockDays,
+        ];
+
+        for (const daySet of overbookableDays) {
+          for (const item of daySet) {
+            if (this.datePicked[0].getTime() < item.getTime()) {
+              relevantLockDays.push(item);
+            }
+          }
+        }
+
+        // Goto right, and check for locked days to increase maxdays limit
+        while (maxDays > 0) {
+          maxDays = maxDays - 1;
+          // nextday from datepicked
+          rightDate = rightDate.add(1, 'day');
+
+          // check if date is lock date and not booked, partially booked or holiday
+          for (const item of relevantLockDays) {
+            if (item.getTime() === rightDate.getTime()) {
+              if (
+                !this.dateIsBooked(rightDate, this.options.bookedDaysInclusivity) &&
+                !this.dateIsPartiallyBooked(
+                  rightDate,
+                  this.options.partiallyBookedDaysInclusivity)
+              ) {
+                if (maxDaysCount <= 0) {
+                  additionalDays = additionalDays + 1;
+                  maxDays = maxDays + 1;
+                } else {
+                  maxDaysCount = maxDaysCount - 1;
                 }
               }
             }

--- a/src/calendar.ts
+++ b/src/calendar.ts
@@ -560,7 +560,6 @@ export class Calendar {
                     maxDaysCount = maxDaysCount - 1 ;
                   } else if (! this.options.countLockedDays) {
                     // don't count any of the locked days
-                    console.log("Not counting anything");
                     additionalDays = additionalDays + 1;
                   }
                 }

--- a/src/calendar.ts
+++ b/src/calendar.ts
@@ -582,12 +582,6 @@ export class Calendar {
                   } else if (this.options.countLockedDays && maxDaysCount >  0) {
                     // in that case the day is counted until the maxDaysCount is reached
                     maxDaysCount = maxDaysCount - 1 ;
-                  } else if (! this.options.countLockedDays) {
-                    // TODO welchen Edge-Case gibt es sodass Überbuchung nicht erlaubt ist?
-                    // TODO kann das raus?
-
-                    // don't count any of the locked days
-                    additionalDays = additionalDays + 1;
                   }
                 }
               }

--- a/src/calendar.ts
+++ b/src/calendar.ts
@@ -536,7 +536,9 @@ export class Calendar {
           let rightDate = this.datePicked[0].clone();
 
           // Max days setting
-          let maxDays = this.options.maxDays; // maximale Anzahl an buchbaren Tagen für eine Buchung -- commonsbooking:src/litepicker.js globalCalendarData['maxDays']
+          // maximale Anzahl an buchbaren Tagen für eine Buchung
+          // -- commonsbooking:src/litepicker.js globalCalendarData['maxDays']
+          let maxDays = this.options.maxDays;
 
           // Maximum number of days that are subtracted, when counting overbooked lockday-blocks
           let maxDaysCount = this.options.countLockedDaysMax;
@@ -558,6 +560,7 @@ export class Calendar {
 
           // Goto right, and check for locked days to increase maxdays limit
           while (maxDays > 0) {
+            // by default, deduct one day from the maximum number of days when going right
             maxDays = maxDays - 1;
             // nextday from datepicked
             rightDate = rightDate.add(1, 'day');
@@ -566,12 +569,14 @@ export class Calendar {
             for (const lockDay of relevantLockDays) {
               if (lockDay.getTime() === rightDate.getTime()) {
                 if (
-                  !this.dateIsBooked(rightDate, this.options.bookedDaysInclusivity) && // TODO was ist booked day inclusivity
+                  // TODO was ist booked day inclusivity
+                  !this.dateIsBooked(rightDate, this.options.bookedDaysInclusivity) &&
                   !this.dateIsPartiallyBooked(
                     rightDate,
                     this.options.partiallyBookedDaysInclusivity)
                 ) {
                   if (this.options.countLockedDays && maxDaysCount <= 0) {
+                    /// in this case, the day is not counted because the maxDaysCount is reached
                     additionalDays = additionalDays + 1;
                     maxDays = maxDays + 1;
                   } else if (this.options.countLockedDays && maxDaysCount >  0) {

--- a/src/calendar.ts
+++ b/src/calendar.ts
@@ -511,7 +511,7 @@ export class Calendar {
       // Days we add to maxdays
       let additionalDays = 0;
 
-      if (!this.options.countLockedDays || this.options.countLockedDaysMax > 0) {
+      if (! this.options.countLockedDays || this.options.countLockedDaysMax > 0) {
         if (!this.options.disallowLockDaysInRange) {
           // First right date
           let rightDate = this.datePicked[0].clone();
@@ -558,6 +558,9 @@ export class Calendar {
                   } else if (this.options.countLockedDays && maxDaysCount >  0) {
                     // in that case the day is counted until the maxDaysCount is reached
                     maxDaysCount = maxDaysCount - 1 ;
+                  } else if (! this.options.countLockedDays) {
+                    // don't count any of the locked days
+                    additionalDays = additionalDays + 1;
                   }
                 }
               }

--- a/src/calendar.ts
+++ b/src/calendar.ts
@@ -525,7 +525,7 @@ export class Calendar {
           // Lockdays > picked date
           const relevantLockDays = [];
           const overbookableDays = [
-            // this.options.holidays,
+            this.options.holidays,
             this.options.lockDays,
           ];
 
@@ -560,6 +560,7 @@ export class Calendar {
                     maxDaysCount = maxDaysCount - 1 ;
                   } else if (! this.options.countLockedDays) {
                     // don't count any of the locked days
+                    console.log("Not counting anything");
                     additionalDays = additionalDays + 1;
                   }
                 }

--- a/src/calendar.ts
+++ b/src/calendar.ts
@@ -530,57 +530,54 @@ export class Calendar {
 
       // This only happens when overbooking is allowed and counting on lockday-blocks is enabled via backend
       if (this.options.countLockedDays && this.options.countLockedDaysMax > 0) {
-        if (!this.options.disallowLockDaysInRange) { // TODO probably redundant, to be removed in backend also
+        // First right date
+        let rightDate = this.datePicked[0].clone();
 
-          // First right date
-          let rightDate = this.datePicked[0].clone();
+        // Maximum number of days for a booking duration
+        // -- commonsbooking:src/litepicker.js globalCalendarData['maxDays']
+        let maxDays = this.options.maxDays;
 
-          // Maximum number of days for a booking duration
-          // -- commonsbooking:src/litepicker.js globalCalendarData['maxDays']
-          let maxDays = this.options.maxDays;
+        // Maximum number of days that are subtracted, when counting overbooked lockday-blocks
+        let maxDaysCount = this.options.countLockedDaysMax;
 
-          // Maximum number of days that are subtracted, when counting overbooked lockday-blocks
-          let maxDaysCount = this.options.countLockedDaysMax;
-
-          // Add all future holidays and lockdays
-          const relevantLockDays = [];
-          const overbookableDays = [
-            this.options.holidays,
-            this.options.lockDays,
-          ];
-          for (const daySet of overbookableDays) {
-            for (const item of daySet) {
-              if (this.datePicked[0].getTime() < item.getTime()) {
-                relevantLockDays.push(item);
-              }
+        // Add all future holidays and lockdays
+        const relevantLockDays = [];
+        const overbookableDays = [
+          this.options.holidays,
+          this.options.lockDays,
+        ];
+        for (const daySet of overbookableDays) {
+          for (const item of daySet) {
+            if (this.datePicked[0].getTime() < item.getTime()) {
+              relevantLockDays.push(item);
             }
           }
+        }
 
-          // Goto right, and check if there are any locked days in the maxday range.
-          // If yes, then increase the maxdays limit
-          while (maxDays > 0) {
-            // by default, deduct one day from the maximum number of days when going right
-            maxDays = maxDays - 1;
-            // nextday from datepicked
-            rightDate = rightDate.add(1, 'day');
+        // Goto right, and check if there are any locked days in the maxday range.
+        // If yes, then increase the maxdays limit
+        while (maxDays > 0) {
+          // by default, deduct one day from the maximum number of days when going right
+          maxDays = maxDays - 1;
+          // nextday from datepicked
+          rightDate = rightDate.add(1, 'day');
 
-            // check if date is lock date and not booked, partially booked or holiday
-            for (const lockDay of relevantLockDays) {
-              if (lockDay.getTime() === rightDate.getTime()) {
-                if (
-                  !this.dateIsBooked(rightDate, this.options.bookedDaysInclusivity) &&
-                  !this.dateIsPartiallyBooked(
-                    rightDate,
-                    this.options.partiallyBookedDaysInclusivity)
-                ) {
-                  if (maxDaysCount <= 0) {
-                    /// in this case, the day is not counted because the maxDaysCount for a lockday-block is reached
-                    additionalDays = additionalDays + 1;
-                    maxDays = maxDays + 1;
-                  } else if (maxDaysCount >  0) {
-                    // in that case the day is counted until the maxDaysCount is reached for a lockday-block
-                    maxDaysCount = maxDaysCount - 1 ;
-                  }
+          // check if date is lock date and not booked, partially booked or holiday
+          for (const lockDay of relevantLockDays) {
+            if (lockDay.getTime() === rightDate.getTime()) {
+              if (
+                !this.dateIsBooked(rightDate, this.options.bookedDaysInclusivity) &&
+                !this.dateIsPartiallyBooked(
+                  rightDate,
+                  this.options.partiallyBookedDaysInclusivity)
+              ) {
+                if (maxDaysCount <= 0) {
+                  /// in this case, the day is not counted because the maxDaysCount for a lockday-block is reached
+                  additionalDays = additionalDays + 1;
+                  maxDays = maxDays + 1;
+                } else if (maxDaysCount >  0) {
+                  // in that case the day is counted until the maxDaysCount is reached for a lockday-block
+                  maxDaysCount = maxDaysCount - 1 ;
                 }
               }
             }

--- a/src/calendar.ts
+++ b/src/calendar.ts
@@ -511,13 +511,16 @@ export class Calendar {
       // Days we add to maxdays
       let additionalDays = 0;
 
-      if (!this.options.countLockedDays) {
+      if (!this.options.countLockedDays || this.options.countLockedDaysMax > 0) {
         if (!this.options.disallowLockDaysInRange) {
           // First right date
           let rightDate = this.datePicked[0].clone();
 
           // Max days setting
           let maxDays = this.options.maxDays;
+
+          // Maximum number of days that should be counted from lockdays
+          let maxDaysCount = this.options.countLockedDaysMax;
 
           // Lockdays > picked date
           const relevantLockDays = [];
@@ -549,58 +552,13 @@ export class Calendar {
                     rightDate,
                     this.options.partiallyBookedDaysInclusivity)
                 ) {
-                  additionalDays = additionalDays + 1;
-                  maxDays = maxDays + 1;
-                }
-              }
-            }
-          }
-        }
-      } else if (this.options.countLockedDaysMax > 0) {
-        // First right date
-        let rightDate = this.datePicked[0].clone();
-
-        // Max days setting
-        let maxDays = this.options.maxDays;
-
-        // Maximum number of days to count
-        let maxDaysCount = this.options.countLockedDaysMax;
-
-        // Lockdays > picked date
-        const relevantLockDays = [];
-        const overbookableDays = [
-          // this.options.holidays,
-          this.options.lockDays,
-        ];
-
-        for (const daySet of overbookableDays) {
-          for (const item of daySet) {
-            if (this.datePicked[0].getTime() < item.getTime()) {
-              relevantLockDays.push(item);
-            }
-          }
-        }
-
-        // Goto right, and check for locked days to increase maxdays limit
-        while (maxDays > 0) {
-          maxDays = maxDays - 1;
-          // nextday from datepicked
-          rightDate = rightDate.add(1, 'day');
-
-          // check if date is lock date and not booked, partially booked or holiday
-          for (const item of relevantLockDays) {
-            if (item.getTime() === rightDate.getTime()) {
-              if (
-                !this.dateIsBooked(rightDate, this.options.bookedDaysInclusivity) &&
-                !this.dateIsPartiallyBooked(
-                  rightDate,
-                  this.options.partiallyBookedDaysInclusivity)
-              ) {
-                if (maxDaysCount <= 0) {
-                  additionalDays = additionalDays + 1;
-                  maxDays = maxDays + 1;
-                } else {
-                  maxDaysCount = maxDaysCount - 1;
+                  if (this.options.countLockedDays && maxDaysCount <= 0) {
+                    additionalDays = additionalDays + 1;
+                    maxDays = maxDays + 1;
+                  } else if (this.options.countLockedDays && maxDaysCount >  0) {
+                    // in that case the day is counted until the maxDaysCount is reached
+                    maxDaysCount = maxDaysCount - 1 ;
+                  }
                 }
               }
             }

--- a/src/calendar.ts
+++ b/src/calendar.ts
@@ -556,7 +556,7 @@ export class Calendar {
             }
           }
         }
-      } else if (this.options.countLockedDaysMax !== 0) {
+      } else if (this.options.countLockedDaysMax > 0) {
         // First right date
         let rightDate = this.datePicked[0].clone();
 

--- a/src/calendar.ts
+++ b/src/calendar.ts
@@ -573,12 +573,12 @@ export class Calendar {
                     rightDate,
                     this.options.partiallyBookedDaysInclusivity)
                 ) {
-                  if (this.options.countLockedDays && maxDaysCount <= 0) {
-                    /// in this case, the day is not counted because the maxDaysCount is reached
+                  if (maxDaysCount <= 0) {
+                    /// in this case, the day is not counted because the maxDaysCount for a lockday-block is reached
                     additionalDays = additionalDays + 1;
                     maxDays = maxDays + 1;
-                  } else if (this.options.countLockedDays && maxDaysCount >  0) {
-                    // in that case the day is counted until the maxDaysCount is reached
+                  } else if (maxDaysCount >  0) {
+                    // in that case the day is counted until the maxDaysCount is reached for a lockday-block
                     maxDaysCount = maxDaysCount - 1 ;
                   }
                 }

--- a/src/calendar.ts
+++ b/src/calendar.ts
@@ -49,21 +49,21 @@ export class Calendar {
     lockDays: [],
     lockDaysInclusivity: '[]',
 
-    // CB Wordpress-Field: Allow locked day overbooking
+    /* CB Wordpress-Field: Allow locked day overbooking */
     disallowLockDaysInRange: true,
 
-    // CB Wordpress-Field: Count locked days when overbooking
+    /* CB Wordpress-Field: Count locked days when overbooking */
     countLockedDays: false,
-    // Schalter ob es gezälhlt werden soll
+    // Enables if number of days of lockday-blocks are counted
 
-    // CB Wordpress-Field: Count connected locked days as one
+    /* CB Wordpress-Field: Count connected locked days as one */
     countLockedDaysMax: 0,
-    // Cutoff, ab wann Tage eins überbuchbaren Blocks
-    // nicht mehr von der maximal erlaubten Anzahl von Buchungstagen
-    // abzogen werden.
-    // Beispiel:
-    //  0 => Jeder überbuchbare Tag eines Blocks wird abgezogen
-    //  1 => Maximal ein Tag wird für einen überbuchbaren Block abgezogen
+    // Cutoff, number of days a connected lockdays-block is interpreted
+    //  at most, when overbookable blocks are substracted from the
+    //  maximum booking duration.
+    // Example values:
+    //  0 => Normal. Each day of the overbookable lockday-block is substracted (as 1).
+    //  1 => Only 1 day is substracted, regardless of the size of the overbookable block of lockdays
     //  ...
 
     holidaysFormat: 'YYYY-MM-DD',
@@ -528,15 +528,14 @@ export class Calendar {
       // Days we add to maxdays
       let additionalDays = 0;
 
-      // Passiert nur bei Überbuchung mit Zählung
+      // This only happens when overbooking is allowed and counting on lockday-blocks is enabled via backend
       if (this.options.countLockedDays && this.options.countLockedDaysMax > 0) {
-        if (!this.options.disallowLockDaysInRange) { // TODO probably redundant
+        if (!this.options.disallowLockDaysInRange) { // TODO probably redundant, to be removed in backend also
 
           // First right date
           let rightDate = this.datePicked[0].clone();
 
-          // Max days setting
-          // maximale Anzahl an buchbaren Tagen für eine Buchung
+          // Maximum number of days for a booking duration
           // -- commonsbooking:src/litepicker.js globalCalendarData['maxDays']
           let maxDays = this.options.maxDays;
 
@@ -544,7 +543,6 @@ export class Calendar {
           let maxDaysCount = this.options.countLockedDaysMax;
 
           // Add all future holidays and lockdays
-          // Lockdays > picked date
           const relevantLockDays = [];
           const overbookableDays = [
             this.options.holidays,
@@ -558,7 +556,8 @@ export class Calendar {
             }
           }
 
-          // Goto right, and check for locked days to increase maxdays limit
+          // Goto right, and check if there are any locked days in the maxday range.
+          // If yes, then increase the maxdays limit
           while (maxDays > 0) {
             // by default, deduct one day from the maximum number of days when going right
             maxDays = maxDays - 1;
@@ -569,7 +568,6 @@ export class Calendar {
             for (const lockDay of relevantLockDays) {
               if (lockDay.getTime() === rightDate.getTime()) {
                 if (
-                  // TODO was ist booked day inclusivity
                   !this.dateIsBooked(rightDate, this.options.bookedDaysInclusivity) &&
                   !this.dateIsPartiallyBooked(
                     rightDate,

--- a/src/litepicker.ts
+++ b/src/litepicker.ts
@@ -2,6 +2,7 @@ import { Calendar } from './calendar';
 import { DateTime } from './datetime';
 import * as style from './scss/main.scss';
 import { findNestedMonthItem, getOrientation, isMobile } from './utils';
+import {isInRange} from "./scss/main.scss";
 
 export class Litepicker extends Calendar {
   protected triggerElement;
@@ -762,19 +763,23 @@ export class Litepicker extends Calendar {
           const dayData = this.options.days[date.format(this.options.bookedDaysFormat)];
           if (dayData.bookedDay) {
             day.classList.add(style.isBooked);
-          } else if (dayData.partiallyBookedDay) {
+          } else if (dayData.partiallyBookedDay && ! (dayData.holiday || dayData.locked)) {
             if (dayData.firstSlotBooked) {
-              if (dayData.holiday) {
-                day.classList.add(style.isLocked);
-              } else {
-                day.classList.add(style.isPartiallyBookedStart);
-              }
+              day.classList.add(style.isPartiallyBookedStart);
             }
             if (dayData.lastSlotBooked) {
               day.classList.add(style.isPartiallyBookedEnd);
             }
           }
-          day.classList.add(style.isInRange);
+          // remove the holiday and locked classes -> can display is in range
+          if (! this.options.disallowLockDaysInRange) {
+            if (dayData.holiday) {
+              day.classList.remove(style.isHoliday);
+            } else if (dayData.locked) {
+              day.classList.remove(style.isLocked);
+            }
+            day.classList.add(isInRange);
+          }
         }
 
         d.className = day.className;

--- a/src/litepicker.ts
+++ b/src/litepicker.ts
@@ -764,7 +764,11 @@ export class Litepicker extends Calendar {
             day.classList.add(style.isBooked);
           } else if (dayData.partiallyBookedDay) {
             if (dayData.firstSlotBooked) {
-              day.classList.add(style.isPartiallyBookedStart);
+              if (dayData.holiday) {
+                day.classList.add(style.isLocked);
+              } else {
+                day.classList.add(style.isPartiallyBookedStart);
+              }
             }
             if (dayData.lastSlotBooked) {
               day.classList.add(style.isPartiallyBookedEnd);


### PR DESCRIPTION
Was ich mit dem Chaos hier erreichen will:
In diesem PR https://github.com/wielebenwir/commonsbooking/pull/1147 ist es schon umgesetzt, man soll in der Lage sein zu definieren, wie viele Tage ein Block von nicht-buchbaren Tagen maximal zählen soll. Damit kann man dann bestimmen, ob z.B. ein verlängertes Wochenende mit drei Tagen nur die zwei Tage zählt usw.

Dafür habe ich den Code einfach kopiert und so lange was geändert bis es funktioniert, verstanden habe ich es nicht.

@markus-mw Vielleicht hast du ja ne sauberere Idee, ansonsten würde ich das so lassen weil das relativ zackig für die Flotte fertig werden muss.