### PR TITLE
Set new default to number of month in portrait mode

### DIFF
--- a/src/litepicker.ts
+++ b/src/litepicker.ts
@@ -248,7 +248,7 @@ export class Litepicker extends Calendar {
 
               // portrait
               default:
-                this.options.numberOfMonths = 1;
+                this.options.numberOfMonths = 2;
                 this.options.numberOfColumns = 1;
                 break;
             }


### PR DESCRIPTION
Otherwise this causes problems with the calendar widgets responsiveness.

Initially requested in main module https://github.com/wielebenwir/commonsbooking/issues/1103